### PR TITLE
Fix migration name

### DIFF
--- a/db/migrate/20170328230616_create_clients.rb
+++ b/db/migrate/20170328230616_create_clients.rb
@@ -1,4 +1,4 @@
-class Clients < ActiveRecord::Migration[5.0]
+class CreateClients < ActiveRecord::Migration[5.0]
   def change
     create_table :clients do |t|
       t.string :name


### PR DESCRIPTION
This migration had the wrong class name and wouldn't migrate. A migration's class name must match it's file name.